### PR TITLE
resolves #102: example Dockerfile to build laminar docker image

### DIFF
--- a/UserManual.md
+++ b/UserManual.md
@@ -43,6 +43,33 @@ Both install packages will create a new `laminar` user and install (but not acti
 
 See the [development README](https://github.com/ohwgiles/laminar) for instructions for installing from source.
 
+## Building for Docker
+
+You can build an image that runs `laminard` by default, and contains `laminarc` for use based on `alpine:edge` using the `Dockerfile` in the `docker/` directory.
+
+```bash
+# from the repository root:
+docker build [-t image:tag] -f docker/Dockerfile .
+```
+
+Keep in mind that this is meant to be used as a base image to build from, so it contains only the minimum packages required to run laminar. The only shell available by default is sh and it does not even have ssh or git. You can use this image to run a basic build server, but it is recommended that you build a custom image from this base to better suit your needs.
+
+The container will execute `laminard` by default. To start a laminar server with docker you can simply run the image as a daemon.
+
+```bash
+docker run -d --name laminar_server -p 8080:8080 [-v laminardir|laminar.conf] laminar:latest
+```
+
+You can customize laminar and persist your data by mounting your laminar directory to `/var/lib/laminar` and/or mounting a custom configuration file to `/etc/laminar.conf`.
+
+Executing `laminarc` may be done in any of the usual ways, for example:
+
+```bash
+docker exec -i laminar_server laminarc queue example_task
+```
+
+Alternatively, you might [use an external `laminarc`](#Triggering-on-a-remote-laminar-instance).
+
 ---
 
 # Service configuration

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,45 @@
+FROM alpine:edge
+
+EXPOSE 8080
+
+LABEL org.label-schema.name="laminar" \
+      org.label-schema.description="Fast and lightweight Continuous Integration" \
+      org.label-schema.usage="/usr/doc/UserManual.md" \
+      org.label-schema.url="https://laminar.ohwg.net" \
+      org.label-schema.vcs-url="https://github.com/ohwgiles/laminar" \
+      org.label-schema.schema-version="1.0" \
+      org.label-schema.docker.cmd="docker run -d -p 8080:8080 laminar"
+
+RUN apk add --no-cache -X http://dl-3.alpinelinux.org/alpine/edge/testing/ \
+        sqlite-dev \
+        zlib \
+        capnproto \
+        tini
+
+ADD UserManual.md /usr/doc/
+
+ADD . /build/laminar
+
+RUN apk add --no-cache --virtual .build -X http://dl-3.alpinelinux.org/alpine/edge/testing/ \
+        build-base \
+        cmake \
+        capnproto-dev \
+        boost-dev \
+        zlib-dev \
+        rapidjson-dev && \
+    cd /build/laminar && \
+    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/ && \
+    make -j4 && \
+    make install && \
+    apk del .build && \
+    rm -rf /build
+
+# Create laminar system user in "users" group
+RUN adduser -SDh /var/lib/laminar -g 'Laminar' -G users laminar
+# Set the working directory to the laminar user's home
+WORKDIR /var/lib/laminar
+# Run the preceeding as the user laminar
+USER laminar
+
+ENTRYPOINT [ "/sbin/tini", "--" ]
+CMD [ "laminard" ]


### PR DESCRIPTION
Create example Dockerfile and document its use in the User Manual.

This provides a minimal Alpine Linux based starting point for users who want to build a custom Laminar Docker container.